### PR TITLE
check vv for custom header without colon

### DIFF
--- a/lib/peer-ssdp.js
+++ b/lib/peer-ssdp.js
@@ -294,7 +294,9 @@ var deserialize = function (msg) {
     lines.forEach(function (line) {
         if (line.length) {
             var vv = line.match(/^([^:]+):\s*(.*)$/);
-            headers[vv[1].toUpperCase()] = vv[2];
+            if(vv && vv.length ===3){
+                headers[vv[1].toUpperCase()] = vv[2];
+            }
         }
     });
     return {


### PR DESCRIPTION
In case of custom header without column, the vv varibale is null and the headers affectation failed.
This pull request correct this point by checking vv && vv.length ===3
